### PR TITLE
Prevent failed parsing of whois servers when encoding is not supported

### DIFF
--- a/website_passive_recon.py
+++ b/website_passive_recon.py
@@ -233,7 +233,7 @@ def do_whois_request(ip, whois_server):
         if not data:
             break
     s.close()
-    return response.decode()
+    return response.decode("utf-8","ignore")
 
 
 def do_whois(ip):


### PR DESCRIPTION
Fix a script crash when there is non utf-8 characters in the response
e.g. `address:        1337 rue de la ville l'�v�que`